### PR TITLE
Add Stripe Connect onboarding flow for organizers

### DIFF
--- a/src/app/organizer/onboarding/refresh/page.tsx
+++ b/src/app/organizer/onboarding/refresh/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+export default function OnboardingRefreshPage() {
+  return (
+    <div className="text-center mt-20">
+      <h1 className="text-2xl font-bold text-yellow-600">⚠️ Onboarding Incomplete</h1>
+      <p>Please complete your Stripe onboarding to receive payments.</p>
+      <button
+        onClick={async () => {
+          const res = await fetch("/api/organizer/stripe/onboard", {
+            method: "POST",
+            body: JSON.stringify({ email: "organizer@example.com" }),
+          });
+          const data = await res.json();
+          window.location.href = data.onboardingUrl;
+        }}
+        className="bg-blue-600 text-white px-4 py-2 mt-4 rounded-md"
+      >
+        Resume Onboarding
+      </button>
+    </div>
+  );
+}

--- a/src/app/organizer/onboarding/success/page.tsx
+++ b/src/app/organizer/onboarding/success/page.tsx
@@ -1,0 +1,44 @@
+
+"use client";
+import { useAppSelector } from "@/redux/hooks";
+import { stripeOnboardingService } from "@/services/organizer/stripeOnboarding";
+import { useEffect, useState } from "react";
+
+export default function OnboardingSuccessPage() {
+  const [verified, setVerified] = useState<boolean | null>(null);
+  const organizer = useAppSelector((state) => state.organizerAuth.organizer);
+
+  useEffect(() => {
+      
+    (async () => {
+           if(!organizer) return
+          try{
+                const res = await stripeOnboardingService.verify(organizer.id)
+          console.log("rerss", res)
+          const data =  res.data.data;
+      setVerified(data.verified);
+          }catch(err){
+             console.log(err)
+          }
+          
+    })();
+  }, [organizer]);
+
+  return (
+    <div className="text-center mt-20">
+      {verified === null ? (
+        <p>Checking your Stripe onboarding status...</p>
+      ) : verified ? (
+        <>
+          <h1 className="text-2xl font-bold text-green-600">🎉 Onboarding Complete</h1>
+          <p>Your account is now ready for payouts.</p>
+        </>
+      ) : (
+        <>
+          <h1 className="text-2xl font-bold text-red-600">⚠️ Onboarding Incomplete</h1>
+          <p>Please return to Stripe and finish your setup.</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/organizer/OrganizerProfile.tsx
+++ b/src/components/organizer/OrganizerProfile.tsx
@@ -14,9 +14,10 @@ import { SecurityTab } from './OrganizerPassword&security';
 import axios from 'axios';
 import { showError, showInfo } from '@/utils/toastService';
 import { setOrganizer, updateKycAndVerificationStatus } from '@/redux/slices/organizer/authSlice';
+import OrganizerPaymentsSection from './payments/OrganizerPaymentsSection';
 
 
-const tabs = ['Profile', 'Documents', 'Verification', 'Security', 'Notifications'];
+const tabs = ['Profile', 'Documents', 'Verification', 'Security',"Payments", 'Notifications'];
 
 type ProfileFormData = {
   organizerId: string;
@@ -79,6 +80,7 @@ export default function OrganizerProfile() {
     const fetchProfile = async () => {
       try {
         if (!organizerId) return;
+        console.log("organ", organizer);
         const response = await profileService.getProfile(organizerId);
         console.log("ress", response)
 
@@ -366,6 +368,11 @@ export default function OrganizerProfile() {
       {activeTab === 'Security' && organizerId && (
         <div className="mt-4">
           <SecurityTab organizerId={organizerId}  />
+        </div>
+      )}
+      {activeTab === 'Payments' && organizerId && (
+        <div className="mt-4">
+             <OrganizerPaymentsSection organizer= {organizer} />
         </div>
       )}
 

--- a/src/components/organizer/UploadDocumentSection.tsx
+++ b/src/components/organizer/UploadDocumentSection.tsx
@@ -72,7 +72,7 @@ export default function UploadDocumentSection({ organizerId }: Props) {
     };
     fetchDocuments();
     setIsUpdating(false)
-  }, [uploading, organizerId,isUpdating, rejectedDocs]);
+  }, [uploading, organizerId,isUpdating]);
 
   const latestStatusMap: Record<string, string> = {};
 documents.forEach((doc) => {

--- a/src/components/organizer/payments/OrganizerPaymentsSection.tsx
+++ b/src/components/organizer/payments/OrganizerPaymentsSection.tsx
@@ -1,0 +1,20 @@
+import { IUser } from "@/types/authTypes";
+import StripeConnectButton from "./StripeConnectButton";
+
+export default function OrganizerPaymentsSection({organizer}:{organizer: IUser}) {
+
+  return (
+        <div className="p-6 bg-gray-100 rounded-lg shadow">
+      <h2 className="text-xl font-bold mb-4">Stripe Connection</h2>
+
+      {organizer.stripeOnboarded ? (
+        <p className="text-green-600 font-semibold">✅ Connected to Stripe</p>
+      ) : (
+        <>
+          <p className="text-gray-600 mb-3">You need to connect your account to Stripe to receive ticket payments.</p>
+          <StripeConnectButton organizerId={organizer.id} email={organizer.email} />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/organizer/payments/StripeConnectButton.tsx
+++ b/src/components/organizer/payments/StripeConnectButton.tsx
@@ -1,0 +1,38 @@
+import { Button } from "@/components/ui/button";
+import { stripeOnboardingService } from "@/services/organizer/stripeOnboarding";
+import { showError } from "@/utils/toastService";
+import { AxiosError } from "axios";
+import { useState } from "react";
+
+export default function StripeConnectButton({organizerId,email}:{organizerId: string, email: string}) {
+  const[loading, setLoading]  = useState(false);
+
+
+  const handleStripeConnect = async () => {
+    try{
+         setLoading(true);
+         const res = await stripeOnboardingService.stripeOnboard(organizerId, email);
+         console.log("res-bu", res)
+        
+         if(res) {
+           window.location.href =res.data.data.onBoardingUrl;
+         }
+
+    }catch(err){
+       if(err instanceof AxiosError){
+            showError(err.response?.data.message)
+       }else{
+          showError("Stripe onboarding failed")
+       }
+       
+    }finally {
+       setLoading(false)
+    }
+  }
+
+  return (
+     <Button  className="bg-green-500 hover:bg-green-700 "  onClick={handleStripeConnect} disabled = {loading}>
+       {loading?"Connecting..." : "Connect with Stripe"}
+     </Button>
+  )
+}

--- a/src/constants/organizer/organizerApiRoutes.ts
+++ b/src/constants/organizer/organizerApiRoutes.ts
@@ -1,0 +1,6 @@
+export const ORGANIZER_API_ROUTES = {
+   STRIPE: {
+     ONBOARDING: `/api/organizer/stripe/onboard`,
+     VERIFY: `/api/organizer/stripe/verify`
+   }
+}

--- a/src/services/organizer/stripeOnboarding.ts
+++ b/src/services/organizer/stripeOnboarding.ts
@@ -1,0 +1,8 @@
+
+import { apiClient } from "../ApiClient";
+import { ORGANIZER_API_ROUTES } from "@/constants/organizer/organizerApiRoutes";
+
+export const stripeOnboardingService = {
+   stripeOnboard : (organizerId: string, email: string) => apiClient.post(ORGANIZER_API_ROUTES.STRIPE.ONBOARDING,{organizerId,email},{withCredentials: true}),
+   verify: (organizerId: string) => apiClient.post(ORGANIZER_API_ROUTES.STRIPE.VERIFY,{organizerId},{withCredentials: true})
+}

--- a/src/types/authTypes.ts
+++ b/src/types/authTypes.ts
@@ -6,7 +6,8 @@ export interface IUser{
   email:string;
   role: "user"|"organizer"|"admin";
   image?:string,
-  isVerified?:boolean
+  isVerified?:boolean,
+  stripeOnboarded?: boolean 
 }
 
 export interface IOrganizer extends IUser{


### PR DESCRIPTION
feat(stripe): implement organizer Stripe Connect onboarding flow

- Added CreateStripeAccountUseCase for connected account creation
- Integrated StripeConnectService for account and onboarding link generation
- Updated organizer repository to store stripeAccountId and onboarding status
- Ensured onboarding prevents duplicate account creation